### PR TITLE
remove npm ecosystem from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,3 @@ updates:
     directory: /
     schedule:
       interval: daily
-
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: daily


### PR DESCRIPTION
## Changes proposed in this pull request:

- remove npm ecosystem from dependabot config so that we don't get constant PRs to this repo anytime one of our dependencies has a new version. We will still get PRs for Dependabot security updates when there is a security issue with our dependencies
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

We will still get PRs for Dependabot security updates when there is a security issue with our dependencies
