### PR TITLE
limit workflow permissions to read-only

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -5,6 +5,9 @@
 # We need to make sure the checked-in `index.js` actually matches what we expect it to be.
 name: Check dist/
 
+permissions:
+  pull-requests: read
+
 on:
   push:
     branches:

--- a/.github/workflows/security-considerations.yml
+++ b/.github/workflows/security-considerations.yml
@@ -1,5 +1,8 @@
 name: Security Considerations
 
+permissions:
+  pull-requests: read
+
 on:
   pull_request:
     types: [opened, edited, reopened]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,8 @@
 name: 'build-test'
+
+permissions:
+  pull-requests: read
+
 on:
   pull_request:
     types: [opened, edited, reopened]


### PR DESCRIPTION
## Changes proposed in this pull request:

- limit workflow permissions to read-only

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Limiting GitHub actions to the minimum permissions necessary to run is good for security
